### PR TITLE
feat: add build-command docs and target command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,32 @@ Or you can clone this repo into your SublimeText Packages directory and rename i
 
 When you see garbage in your editor change the syntax to `ANSI` and you're good!
 
-### Using this plugin as a dependency for your build output
-If you're writing a plugin that builds something using a shell command and shows the results in an output panel, use this plugin! Do not remove ANSI codes, just set the syntax file of your output to `Packages/ANSIescape/ANSI.tmLanguage` and ANSI will take care of color highlighting your terminal output. 
+The plugin works by detecting the syntax change event and marking ANSI color chars regions with the appropriate scopes matching the style defined in a tmTheme file.
+
+### Using this plugin as a dependency for your plugin/build output panel
+If you're writing a plugin that builds something using a shell command and shows the results in an output panel, use this plugin! Do not remove ANSI codes, just set the syntax file of your output to `Packages/ANSIescape/ANSI.tmLanguage` and ANSI will take care of color highlighting your terminal output.
+
+Likewise, if you would like to display ANSI colors in your existing [build-command](http://sublime-text-unofficial-documentation.readthedocs.org/en/latest/reference/build_systems/basics.html) output, you would only need to set `ansi_color_build` as the target and `Packages/ANSIescape/ANSI.tmLanguage` as the syntax; for example:
+
+```javascript
+// someproject.sublime-project
+{
+    "build_systems":
+    [
+        {
+            /* your existing build command arguments */
+            "name": "Run",
+            "working_dir": "${project_path}/src",
+            "env": {"PYTHONPATH": ".../venv/python2.7/site-packages"},
+            "cmd": ["nosetests", "--rednose"],
+
+            /*  add target and syntax */
+            "target": "ansi_color_build",
+            "syntax": "Packages/ANSIescape/ANSI.tmLanguage"
+        }
+    ]
+}
+```
 
 ### Customizing ANSI colors
 All the colors used to highlight ANSI escape code can be customized through 

--- a/ansi.py
+++ b/ansi.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import sublime, sublime_plugin, os
+import Default
 
 DEBUG = False
 
@@ -66,6 +67,17 @@ class AnsiEventListener(sublime_plugin.EventListener):
             view.run_command("ansi")
         elif view.settings().get("ansi_enabled"):
             view.window().run_command("undo_ansi")
+
+
+class AnsiColorBuildCommand(Default.exec.ExecCommand):
+    def on_finished(self, proc):
+        super(AnsiColorBuildCommand, self).on_finished(proc)
+
+        view = self.output_view
+        if view.settings().get("syntax") == "Packages/ANSIescape/ANSI.tmLanguage":
+            view.settings().set("ansi_enabled", False)
+            self.output_view.set_read_only(False)
+            view.run_command('ansi')
 
 
 CS_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
resolve issue #1

### Details

AnsiColorBuildCommand is simply the Default.exec command with on_finished hook overridden to call on AnsiCommand when with build, this is done since more characters (with more ANSI codes) may be written while the command is still running.
