### PR TITLE
Improve performance for large file

### DIFF
--- a/ansi.py
+++ b/ansi.py
@@ -34,13 +34,12 @@ class AnsiCommand(sublime_plugin.TextCommand):
             v.replace(edit, r, "\x1b[1m")
 
         # collect colors from file content and make them a string
-        color_str = '\x1b' + '\x1b'.join({
-            v for v in
+        color_str = '\x1b' + '\x1b'.join(set(
             re.findall(
                 r'(\[[\d;]*m)', # find all possible colors
                 v.substr(sublime.Region(0, v.size())) # file content
             )
-        }) + '\x1b'
+        )) + '\x1b'
 
         settings = sublime.load_settings("ansi.sublime-settings")
         # filter out unnecessary colors in user settings

--- a/ansi.py
+++ b/ansi.py
@@ -57,7 +57,7 @@ class AnsiCommand(sublime_plugin.TextCommand):
                     sum_regions = v.get_regions(ansi_scope) + ansi_regions
                     v.add_regions(ansi_scope, sum_regions, ansi_scope, '', sublime.DRAW_NO_OUTLINE)
 
-        # removing the rest of  ansi escape codes
+        # removing the rest of ansi escape codes
         ansi_codes = v.find_all(r'(\x1b\[[\d;]*m){1,}')
         ansi_codes.reverse()
         for r in ansi_codes:
@@ -83,6 +83,7 @@ class UndoAnsiCommand(sublime_plugin.WindowCommand):
         view.settings().erase("ansi_scratch")
         view.set_read_only(view.settings().get("ansi_read_only", False))
         view.settings().erase("ansi_read_only")
+
 
 class AnsiEventListener(sublime_plugin.EventListener):
 
@@ -188,7 +189,8 @@ def plugin_loaded():
     settings.add_on_change("ANSI_SETTINGS_CHANGE", lambda: AnsiColorBuildCommand.update_build_settings())
     for window in sublime.windows():
         for view in window.views():
-           AnsiEventListener().assign_event_listner(view)
+            AnsiEventListener().assign_event_listner(view)
+
 
 def plugin_unloaded():
     settings = sublime.load_settings("ansi.sublime-settings")

--- a/ansi.py
+++ b/ansi.py
@@ -34,12 +34,13 @@ class AnsiCommand(sublime_plugin.TextCommand):
             v.replace(edit, r, "\x1b[1m")
 
         # collect colors from file content and make them a string
-        color_str = '\x1b' + '\x1b'.join(set(
-            re.findall(
+        color_str = "{0}{1}{0}".format(
+            '\x1b',
+            '\x1b'.join(set(re.findall(
                 r'(\[[\d;]*m)', # find all possible colors
                 v.substr(sublime.Region(0, v.size())) # file content
-            )
-        )) + '\x1b'
+            )))
+        )
 
         settings = sublime.load_settings("ansi.sublime-settings")
         # filter out unnecessary colors in user settings


### PR DESCRIPTION
The original [line 40](https://github.com/aziz/SublimeANSI/blob/addcaeaa416bf4fdabb9f55d32c93a999e049098/ansi.py#L40) in a nested loop is pretty slow when our file content gets larger. Remove unnecessary colors, which do not appear in the file content, to gain some speed.

I use `git log --graph --date=short --pretty=format:'%C(yellow bold)%h%Creset%C(auto)%d%Creset - %s %C(green bold)[%an]%Creset %C(blue bold)(%ad, %cr)%Creset'` in the custom command from SublimeSideBarGit to test, which looks like the following screenshot.

![image](https://raw.githubusercontent.com/jfcherng/Sublime-AutoSetSyntax/gh-pages/images/example/git-log.gif)