### PR TITLE
Add Package Control package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin solves this annoying problem. Not by just removing the ANSI escape c
 
 ## Installation
 
-You can install via [Sublime Package Control](http://wbond.net/sublime_packages/package_control)  
+You can install via [Sublime Package Control](https://packagecontrol.io/installation): [ANSIescape](https://packagecontrol.io/packages/ANSIescape)  
 Or you can clone this repository into your SublimeText Packages directory and rename it to `ANSIescape`
 
 ## Usage


### PR DESCRIPTION
This repository and project has a different name than what you find in Sublime when trying to install the package.  This will help people install the plugin more naturally.