### PR TITLE
Dramatic performance improvement for large static content

### DIFF
--- a/ansi.sublime-settings
+++ b/ansi.sublime-settings
@@ -19,7 +19,7 @@
       {"scope": "_bold", "code": "\\x1b\\[(0;)?1m", "color": "#ffffff", "font_style": "bold"}
   ],
   "ANSI_BG": [
-      {"scope": "", "code": "(?<!\\x1b\\[0;4(0|1|2|3|4|5|6|7)m)(?<!\\x1b\\[4(0|1|2|3|4|5|6|7)m)", "color": "#010000"},
+      {"scope": "", "code": "(?<!\\x1b\\[0;4[01234567]m)(?<!\\x1b\\[4[01234567]m)", "color": "#010000"},
       {"scope": "_bg_black", "code": "\\x1b\\[(0;)?40m", "color": "#222222"},
       {"scope": "_bg_red", "code": "\\x1b\\[(0;)?41m", "color": "#c71e12"},
       {"scope": "_bg_green", "code": "\\x1b\\[(0;)?42m", "color": "#00c120"},


### PR DESCRIPTION
After some profiling, I found that almost all time is spent on [erasing the ansi codes](https://github.com/aziz/SublimeANSI/blob/390b0fb8fc6a2c5146d69041f6e49436cdaf69a8/ansi.py#L163-L167). I guess that's because we have rendered (i.e., `view.add_regions()`) the content before erasing ansi codes and that makes ST do lots of extra calculations and renderings during the erasing step. Thus, I tried to do erasing first, calculate/correct offsets by myself and move the rendering step to the last. Eventually, I feel like 5~10x speedup on my machine with the given test case mentioned later.

Techniques:
- use cached compiled regex object
- move the rendering process to the last step (major improvement)

Fix https://github.com/aziz/SublimeANSI/issues/42 with the [test case](https://github.com/aziz/SublimeANSI/files/1482845/development.log).


Another test case from official ST's package git log [sublime_package_git_log.log](https://github.com/aziz/SublimeANSI/files/1484010/sublime_package_git_log.log).
