### PR TITLE
Wait for ExecCommand before colorizing

### DIFF
--- a/ansi.py
+++ b/ansi.py
@@ -411,8 +411,9 @@ class AnsiColorBuildCommand(Default.exec.ExecCommand):
         # send on_data without ansi codes
         super(AnsiColorBuildCommand, self).on_data(proc, out_data)
 
-        # send ansi command
-        view.run_command('ansi', args={"regions": json_ansi_regions})
+        # wait some time for the output to be process by ExecCommand before
+        # sending ansi command
+        sublime.set_timeout_async(lambda: view.run_command('ansi', args={"regions": json_ansi_regions}), 1)
 
     def on_data(self, proc, data):
         if self.process_trigger == "on_data":


### PR DESCRIPTION
ExecCommand uses a short timeout internally to append the data to the view. If this timeout isn't fired fast enough the regions can't be colored. A simple solution is to also add a timeout to the colorization.

This could still be improved a little by checking whether the regions are within the view size, and only use a timeout if they are not. That would remove some rare flickering introduced by the timeout.