### PR TITLE
Fix race condition leading to AttributeError

### DIFF
--- a/ansi.py
+++ b/ansi.py
@@ -370,11 +370,12 @@ class AnsiEventListener(sublime_plugin.EventListener):
                 view.window().run_command("undo_ansi")
 
     def _is_view_valid(self, view):
-        if view.window() is None:
+        window = view.window()
+        if window is None:
             return False
-        if view.window() not in sublime.windows():
+        if window not in sublime.windows():
             return False
-        if view not in view.window().views():
+        if view not in window.views():
             return False
         return True
 
@@ -447,7 +448,7 @@ class AnsiColorBuildCommand(Default.exec.ExecCommand):
         for region in ansi_regions:
             region.shift(shift_val)
             json_ansi_regions.update(region.jsonable())
-            
+
         # send on_data without ansi codes
         super(AnsiColorBuildCommand, self).on_data(proc, out_data)
 


### PR DESCRIPTION
Hello @aziz.

I've seen this error multiple times over the months (years?), without ever being able to come up with a reproducing test case. It just shows up from time to time. Long story short: these 2 lines check whether `window is not None`:
https://github.com/aziz/SublimeANSI/blob/master/ansi.py#L373-L374.
Window may not be None at line 373, but it can turn to None at lines 375 and 377 (this is the race condition). The error that can be seen in ST console is:

```
  File "/home/giampaolo/.config/sublime-text/Installed Packages/ANSIescape.sublime-package/ansi.py", line 343, in check_left_ansi
    if not self._is_view_valid(view):
  File "/home/giampaolo/.config/sublime-text/Installed Packages/ANSIescape.sublime-package/ansi.py", line 377, in _is_view_valid
    if view not in view.window().views():
AttributeError: 'NoneType' object has no attribute 'views'
```